### PR TITLE
Add greater flexibility in timestamps

### DIFF
--- a/src/timestamps.js
+++ b/src/timestamps.js
@@ -58,7 +58,8 @@ export default {
       if (!model.schema.properties[fields.createdAt]) {
         model.schema.properties[fields.createdAt] = {
           format: 'date-time',
-          type: 'string'
+          type: 'string',
+          final: true
         };
       }
       if (!model.schema.properties[fields.updatedAt]) {

--- a/test/timestamps.test.js
+++ b/test/timestamps.test.js
@@ -28,19 +28,141 @@ test(`timestamps are not inserted when absent`, async () => {
   await teardown(db);
 });
 
-test(`timestamps are inserted`, async () => {
+test(`timestamps are inserted when flagged true on database only`, async () => {
   expect.assertions(2);
 
-  const db = await setup();
-  await db.collection({
-    ...model('items'),
-    options: { timestamps: true }
-  });
+  const db = await setup({ timestamps: true });
+  await db.collection(model('items'));
   await db.collections.items.insert({});
   const item = await db.collections.items.findOne().exec();
 
   expect(item.createdAt).not.toBe(undefined);
   expect(item.updatedAt).not.toBe(undefined);
+  await teardown(db);
+});
+
+test(`timestamps are inserted properly with database overrides only`, async () => {
+  expect.assertions(4);
+
+  const db = await setup({
+    timestamps: {
+      createdAt: 'created_renamed',
+      updatedAt: 'updated_renamed'
+    }
+  });
+  await db.collection(model('items'));
+  await db.collections.items.insert({});
+  const item = await db.collections.items.findOne().exec();
+
+  expect(item.createdAt).toBe(undefined);
+  expect(item.updatedAt).toBe(undefined);
+  expect(item.created_renamed).not.toBe(undefined);
+  expect(item.updated_renamed).not.toBe(undefined);
+  await teardown(db);
+});
+
+test(`timestamps are inserted when flagged true on collection only`, async () => {
+  expect.assertions(4);
+
+  const db = await setup();
+  await db.collection(model('items'));
+  await db.collection({
+    ...model('overrides'),
+    options: { timestamps: true }
+  });
+  await db.collections.items.insert({});
+  await db.collections.overrides.insert({});
+  const item = await db.collections.items.findOne().exec();
+  const override = await db.collections.overrides.findOne().exec();
+
+  expect(item.createdAt).toBe(undefined);
+  expect(item.updatedAt).toBe(undefined);
+  expect(override.createdAt).not.toBe(undefined);
+  expect(override.updatedAt).not.toBe(undefined);
+
+  await teardown(db);
+});
+
+test(`timestamps are inserted with collection overrides only`, async () => {
+  expect.assertions(8);
+
+  const db = await setup();
+  await db.collection(model('items'));
+  await db.collection({
+    ...model('overrides'),
+    options: {
+      timestamps: {
+        createdAt: 'created_renamed',
+        updatedAt: 'updated_renamed'
+      }
+    }
+  });
+  await db.collections.items.insert({});
+  await db.collections.overrides.insert({});
+  const item = await db.collections.items.findOne().exec();
+  const override = await db.collections.overrides.findOne().exec();
+
+  expect(item.createdAt).toBe(undefined);
+  expect(item.updatedAt).toBe(undefined);
+  expect(item.created_renamed).toBe(undefined);
+  expect(item.updated_renamed).toBe(undefined);
+  expect(override.createdAt).toBe(undefined);
+  expect(override.updatedAt).toBe(undefined);
+  expect(override.created_renamed).not.toBe(undefined);
+  expect(override.updated_renamed).not.toBe(undefined);
+  await teardown(db);
+});
+
+test(`timestamps are inserted properly when collection overrides defaults`, async () => {
+  expect.assertions(8);
+
+  const db = await setup({ timestamps: true });
+
+  await db.collection(model('items'));
+  await db.collection({
+    ...model('overrides'),
+    options: {
+      timestamps: {
+        createdAt: 'created_renamed',
+        updatedAt: 'updated_renamed'
+      }
+    }
+  });
+  await db.collections.items.insert({});
+  await db.collections.overrides.insert({});
+  const item = await db.collections.items.findOne().exec();
+  const override = await db.collections.overrides.findOne().exec();
+
+  expect(item.createdAt).not.toBe(undefined);
+  expect(item.updatedAt).not.toBe(undefined);
+  expect(item.created_renamed).toBe(undefined);
+  expect(item.updated_renamed).toBe(undefined);
+  expect(override.createdAt).toBe(undefined);
+  expect(override.updatedAt).toBe(undefined);
+  expect(override.created_renamed).not.toBe(undefined);
+  expect(override.updated_renamed).not.toBe(undefined);
+});
+
+test(`timestamps are not inserted when collection disables`, async () => {
+  expect.assertions(4);
+
+  const db = await setup({ timestamps: true });
+
+  await db.collection(model('items'));
+  await db.collection({
+    ...model('overrides'),
+    options: { timestamps: false }
+  });
+  await db.collections.items.insert({});
+  await db.collections.overrides.insert({});
+  const item = await db.collections.items.findOne().exec();
+  const override = await db.collections.overrides.findOne().exec();
+
+  expect(item.createdAt).not.toBe(undefined);
+  expect(item.updatedAt).not.toBe(undefined);
+  expect(override.createdAt).toBe(undefined);
+  expect(override.updatedAt).toBe(undefined);
+
   await teardown(db);
 });
 

--- a/test/utils/db.js
+++ b/test/utils/db.js
@@ -12,12 +12,13 @@ registerUtils(RxDB);
 
 const nameGen = () => 'a' + uuid().replace(/[^a-zA-Z0-9]/g, '');
 
-function setup() {
+function setup(options) {
   return RxDB.create({
     name: nameGen(),
     adapter: 'memory',
     multiInstance: false,
-    ignoreDuplicate: true
+    ignoreDuplicate: true,
+    options: options
   });
 }
 


### PR DESCRIPTION
This adds a few features, but is 100% backwards compatible:

1. options can be set on the database rather than individual collections, and can be overridden by collection.
```js
const db = await RxDB.create({
  name: 'examples',
  options: { timestamps: true }
});
const users = await db.collection({
  name: 'items',
  ...
  options: { timestamps: false }
});
```

2. options at both levels can accept field name overrides:
```js
const db = await RxDB.create({
  name: 'examples',
  options: { 
    timestamps: {
      createdAt: 'created',
      updatedAt: 'modified'
    }
  }
});
```

Unit tests included.